### PR TITLE
Add voyageai module to dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,6 +81,20 @@ Installing Cognee with PostgreSQL and Neo4j support example:
 poetry add cognee -E postgres -E neo4j
 ```
 
+### With pip with voyageai support
+
+To install Cognee with support for voyageai use the appropriate command below.
+```bash
+pip install 'cognee[voyageai]'
+```
+
+### With poetry with voyageai support
+
+To install Cognee with support for voyageai use the appropriate command below.
+```bash
+poetry add cognee -E voyageai
+```
+
 ## 💻 Basic Usage
 
 ### Setup

--- a/cognee-mcp/pyproject.toml
+++ b/cognee-mcp/pyproject.toml
@@ -8,6 +8,7 @@ requires-python = ">=3.10"
 dependencies = [
     "cognee[codegraph]",
     "mcp==1.2.1",
+    "voyageai"
 ]
 
 [[project.authors]]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -84,7 +84,7 @@ tree-sitter = {version = "^0.24.0", optional = true}
 tree-sitter-python = {version = "^0.23.6", optional = true}
 plotly = {version = "^6.0.0", optional = true}
 gdown = {version = "^5.2.0", optional = true}
-
+voyageai = {version = "^1.0.0", optional = true}
 
 [tool.poetry.extras]
 filesystem = ["s3fs", "botocore"]
@@ -104,7 +104,7 @@ falkordb = ["falkordb"]
 groq = ["groq"]
 milvus = ["pymilvus"]
 docs = ["unstructured"]
-codegraph = ["fastembed", "tree-sitter", "tree-sitter-python"]
+codegraph = ["fastembed", "tree-sitter", "tree-sitter-python", "voyageai"]
 evals = ["plotly", "gdown"]
 
 [tool.poetry.group.dev.dependencies]


### PR DESCRIPTION
Add `voyageai` module to dependencies and update installation instructions.

* Add `voyageai` to the `[tool.poetry.dependencies]` section in `pyproject.toml`.
* Add `voyageai` to the `[tool.poetry.extras]` section under `codegraph` in `pyproject.toml`.
* Add `voyageai` to the `dependencies` section in `cognee-mcp/pyproject.toml`.
* Update `README.md` to include installation instructions for `voyageai`.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/NitashEU/cognee/pull/2?shareId=4bdb5f5c-def1-4ba7-83ed-97840184eeec).